### PR TITLE
Fix pip dependencies broken since ginkgo.1, and mongo replicaset read_preference

### DIFF
--- a/common/lib/chem/setup.py
+++ b/common/lib/chem/setup.py
@@ -10,4 +10,7 @@ setup(
         "scipy==0.14.0",
         "nltk==2.0.6",
     ],
+    dependency_links=[
+        "git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6",
+    ],
 )

--- a/common/lib/xmodule/xmodule/modulestore/django.py
+++ b/common/lib/xmodule/xmodule/modulestore/django.py
@@ -24,7 +24,6 @@ import django.dispatch
 import django.utils
 from django.utils.translation import get_language, to_locale
 
-from pymongo import ReadPreference
 from xmodule.contentstore.django import contentstore
 from xmodule.modulestore.draft_and_published import BranchSettingMixin
 from xmodule.modulestore.mixed import MixedModuleStore
@@ -275,9 +274,6 @@ def create_modulestore_instance(
         xb_user_service = DjangoXBlockUserService(get_current_user())
     else:
         xb_user_service = None
-
-    if 'read_preference' in doc_store_config:
-        doc_store_config['read_preference'] = getattr(ReadPreference, doc_store_config['read_preference'])
 
     xblock_field_data_wrappers = [load_function(path) for path in settings.XBLOCK_FIELD_DATA_WRAPPERS]
 

--- a/common/lib/xmodule/xmodule/mongo_utils.py
+++ b/common/lib/xmodule/xmodule/mongo_utils.py
@@ -4,6 +4,7 @@ Common MongoDB connection functions.
 import logging
 
 import pymongo
+from pymongo import ReadPreference
 from mongodb_proxy import MongoProxy
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -32,6 +33,13 @@ def connect_to_mongodb(
     else:
         # No 'replicaSet' in kwargs - so no secondary reads.
         mongo_client_class = pymongo.MongoClient
+
+    # If read_preference is given as a name of a valid ReadPreference.<NAME> constant
+    # such as "SECONDARY_PREFERRED", convert it. Otherwise pass it through unchanged.
+    if 'read_preference' in kwargs:
+        read_preference = getattr(ReadPreference, kwargs['read_preference'], None)
+        if read_preference is not None:
+            kwargs['read_preference'] = read_preference
 
     mongo_conn = pymongo.database.Database(
         mongo_client_class(

--- a/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
+++ b/common/lib/xmodule/xmodule/tests/test_mongo_utils.py
@@ -1,0 +1,38 @@
+"""
+Tests for methods defined in mongo_utils.py
+"""
+import ddt
+import os
+from unittest import TestCase
+from uuid import uuid4
+
+from pymongo import ReadPreference
+
+from django.conf import settings
+
+from xmodule.mongo_utils import connect_to_mongodb
+
+
+@ddt.ddt
+class MongoUtilsTests(TestCase):
+    """
+    Tests for methods exposed in mongo_utils
+    """
+    @ddt.data(
+        ('PRIMARY', 'primary', ReadPreference.PRIMARY),
+        ('SECONDARY_PREFERRED', 'secondaryPreferred', ReadPreference.SECONDARY_PREFERRED),
+        ('NEAREST', 'nearest', ReadPreference.NEAREST),
+    )
+    @ddt.unpack
+    def test_connect_to_mongo_read_preference(self, enum_name, mongos_name, expected_read_preference):
+        """
+        Test that read_preference parameter gets converted to a valid pymongo read preference.
+        """
+        host = 'edx.devstack.mongo' if 'BOK_CHOY_HOSTNAME' in os.environ else 'localhost'
+        db = 'test_read_preference_%s' % uuid4().hex
+        # Support for read_preference given in constant name form (ie. PRIMARY, SECONDARY_PREFERRED)
+        connection = connect_to_mongodb(db, host, read_preference=enum_name)
+        self.assertEqual(connection.client.read_preference, expected_read_preference)
+        # Support for read_preference given as mongos name.
+        connection = connect_to_mongodb(db, host, read_preference=mongos_name)
+        self.assertEqual(connection.client.read_preference, expected_read_preference)

--- a/requirements/edx/github.txt
+++ b/requirements/edx/github.txt
@@ -47,7 +47,7 @@
 
 # Third-party:
 git+https://github.com/cyberdelia/django-pipeline.git@1.5.3#egg=django-pipeline==1.5.3
-git+https://github.com/edx/django-wiki.git@v0.0.10#egg=django-wiki==0.0.10
+git+https://github.com/open-craft/django-wiki.git@opencraft-release/ginkgo.1#egg=django-wiki==0.0.10
 git+https://github.com/edx/django-openid-auth.git@0.8#egg=django-openid-auth==0.8
 git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
 git+https://github.com/edx/nltk.git@2.0.6#egg=nltk==2.0.6


### PR DESCRIPTION
This change incorporates two changes that fix pip dependencies that broke since `open-release/ginkgo.1` was released.

Also incorporates a change that makes it possible to configure the mongo replicaset read preferences during deployment.

* 32c87ab: cf https://github.com/open-craft/edx-platform/pull/78, and https://github.com/edx/edx-platform/commit/f8804992ef69fee5318008d06111aa126a5a4b43.
* b8d0240: cf https://github.com/open-craft/edx-platform/pull/79
* 50c1a4e: cf https://github.com/edx/edx-platform/pull/16540, https://github.com/DukeLearningInnovation/configuration/pull/6

**Reviewer**
 - [  ] @bdero