### PR TITLE
Adds redirect middleware to Studio

### DIFF
--- a/cms/envs/common.py
+++ b/cms/envs/common.py
@@ -385,6 +385,9 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.sites.middleware.CurrentSiteMiddleware',
 
+    # Allows us to define redirects via Django admin
+    'django_sites_extensions.middleware.RedirectMiddleware',
+
     # Instead of SessionMiddleware, we use a more secure version
     # 'django.contrib.sessions.middleware.SessionMiddleware',
     'openedx.core.djangoapps.safe_sessions.middleware.SafeSessionMiddleware',


### PR DESCRIPTION
We need Django redirects in Studio to allow SSO for Studio signin/signup links.

Django redirect middleware exists in the LMS but not Studio, so this change rectifies this.

**JIRA issues**

OC-3449

**Testing instructions**

* In LMS (or CMS) Django Admin, ensure there is a Site entry for the studio site URL.
* Create a Redirect using the studio Site entry.
* Test to ensure this redirect works.

This can be tested on https://studio.stage.extend.duke.edu by clicking on the Signin or Signup buttons, and noting that you are redirected through OneLink.

**Reviewer**
- [x] @smarnach 